### PR TITLE
Add power of the moon azerite power to feral

### DIFF
--- a/profiles/Azerite/AzeritePower.json
+++ b/profiles/Azerite/AzeritePower.json
@@ -3557,7 +3557,8 @@
         "spellId": 273367,
         "spellName": "Power of the Moon",
         "specsId": [
-            102
+            102,
+            103
         ],
         "tier": 3,
         "classesId": [


### PR DESCRIPTION
The trait does work very well with certain feral talent setups and is highly relevant for especially combination sims.